### PR TITLE
feat: Add rock-ci-metadata.yaml

### DIFF
--- a/metacontroller/rock-ci-metadata.yaml
+++ b/metacontroller/rock-ci-metadata.yaml
@@ -1,0 +1,6 @@
+integrations:
+  - consumer-repository: https://github.com/canonical/metacontroller-operator.git
+
+    replace-image:
+      - file: config.yaml
+        path: options.metacontroller-image.default


### PR DESCRIPTION
Introduce a `rock-ci-metadata.yaml` for rock integration. For full file
creation steps, refer to
https://github.com/canonical/pipelines-rocks/issues/200#issuecomment-3112245114.

Closes #27
